### PR TITLE
feat: store uploads in azure blob storage

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,66 @@ const DATA_DIR = __dirname;
 const UPLOAD_DIR = path.join(DATA_DIR, 'uploads');
 const METADATA_FILE = path.join(DATA_DIR, 'videos.json');
 
+const DEFAULT_AZURE_CONTAINER_SAS_URL =
+  'https://zeusvideos.blob.core.windows.net/zeusvideos?sp=racwdl&st=2025-09-25T04:14:06Z&se=2026-09-25T12:29:06Z&spr=https&sv=2024-11-04&sr=c&sig=94DrfYtVMAA1VWmR8nkuCK%2FAvv1kxcJRjRNwZdv8mGY%3D';
+
+const azureConfig = initializeAzureConfig(
+  process.env.AZURE_CONTAINER_SAS_URL || DEFAULT_AZURE_CONTAINER_SAS_URL,
+);
+
+function initializeAzureConfig(sasUrl) {
+  if (!sasUrl) {
+    console.warn('Azure Blob Storage SAS URL is not configured.');
+    return null;
+  }
+
+  try {
+    const parsed = new URL(sasUrl);
+    if (!parsed.search) {
+      console.warn('Azure Blob Storage SAS URL is missing the SAS query string.');
+    }
+
+    const basePath = parsed.pathname.replace(/\/$/, '');
+    return {
+      baseUrl: `${parsed.origin}${basePath}`,
+      query: parsed.search,
+    };
+  } catch (error) {
+    console.error('Invalid Azure Blob Storage SAS URL provided:', error);
+    return null;
+  }
+}
+
+function buildAzureBlobUrl(blobName) {
+  if (!azureConfig) {
+    throw new Error('Azure Blob Storage is not configured.');
+  }
+
+  const encodedName = encodeURIComponent(blobName);
+  return `${azureConfig.baseUrl}/${encodedName}${azureConfig.query}`;
+}
+
+async function uploadToAzureBlob(blobName, buffer, mimeType) {
+  const blobUrl = buildAzureBlobUrl(blobName);
+  const response = await fetch(blobUrl, {
+    method: 'PUT',
+    headers: {
+      'x-ms-blob-type': 'BlockBlob',
+      'x-ms-version': '2022-11-02',
+      'Content-Type': mimeType || 'application/octet-stream',
+      'Content-Length': buffer.length.toString(),
+    },
+    body: buffer,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Azure Blob upload failed with status ${response.status}: ${text}`);
+  }
+
+  return blobUrl;
+}
+
 function ensureEnvironment() {
   if (!fs.existsSync(UPLOAD_DIR)) {
     fs.mkdirSync(UPLOAD_DIR, { recursive: true });
@@ -91,8 +151,25 @@ function parseRequestBody(req) {
   });
 }
 
-function handleUpload(body) {
-  const { title, description, originalName, folder, data } = body;
+const VIDEO_MIME_TYPES = {
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.m4v': 'video/x-m4v',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+};
+
+function resolveMimeType(extension, providedMime) {
+  if (providedMime && typeof providedMime === 'string' && providedMime.trim()) {
+    return providedMime;
+  }
+
+  const normalized = extension.toLowerCase();
+  return VIDEO_MIME_TYPES[normalized] || 'application/octet-stream';
+}
+
+async function handleUpload(body) {
+  const { title, description, originalName, folder, data, mimeType } = body;
 
   if (!title || !description || !originalName || !data) {
     const missing = ['title', 'description', 'originalName', 'data'].filter((key) => !body[key]);
@@ -105,17 +182,27 @@ function handleUpload(body) {
 
   const extension = path.extname(originalName) || '.mp4';
   const fileName = `${Date.now()}-${randomUUID()}${extension}`;
-  const filePath = path.join(UPLOAD_DIR, fileName);
+  const mime = resolveMimeType(extension, mimeType);
 
-  try {
-    const buffer = Buffer.from(data, 'base64');
-    fs.writeFileSync(filePath, buffer);
-  } catch (error) {
-    console.error('Failed to save uploaded file:', error);
+  if (!azureConfig) {
+    console.error('Azure Blob Storage is not configured. Unable to upload file.');
     return {
       error: true,
       status: 500,
-      message: 'Failed to save uploaded file.',
+      message: 'File storage service is not configured.',
+    };
+  }
+
+  let blobUrl;
+  try {
+    const buffer = Buffer.from(data, 'base64');
+    blobUrl = await uploadToAzureBlob(fileName, buffer, mime);
+  } catch (error) {
+    console.error('Failed to upload file to Azure Blob Storage:', error);
+    return {
+      error: true,
+      status: 502,
+      message: 'Failed to store uploaded file.',
     };
   }
 
@@ -127,7 +214,7 @@ function handleUpload(body) {
     folder: folder || 'Unsorted',
     originalName,
     fileName,
-    url: `/uploads/${fileName}`,
+    url: blobUrl,
     createdAt: new Date().toISOString(),
   };
 
@@ -166,7 +253,7 @@ const server = http.createServer(async (req, res) => {
   if (method === 'POST' && url === '/api/videos') {
     try {
       const body = await parseRequestBody(req);
-      const result = handleUpload(body);
+      const result = await handleUpload(body);
       if (result.error) {
         sendJson(res, result.status, { message: result.message });
         return;
@@ -182,8 +269,39 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (method === 'GET' && url.startsWith('/uploads/')) {
-    const relativePath = path.normalize(url.replace('/uploads/', ''));
-    const filePath = path.resolve(UPLOAD_DIR, relativePath);
+    const rawPath = url.slice('/uploads/'.length);
+    let decodedPath = '';
+    try {
+      decodedPath = decodeURIComponent(rawPath);
+    } catch (error) {
+      console.warn('Failed to decode upload path:', error);
+      sendJson(res, 400, { message: 'Invalid file path.' });
+      return;
+    }
+
+    const normalizedPath = decodedPath.replace(/\\/g, '/').replace(/^\/+/, '');
+
+    if (!normalizedPath || normalizedPath.includes('..')) {
+      sendJson(res, 400, { message: 'Invalid file path.' });
+      return;
+    }
+
+    if (azureConfig) {
+      try {
+        const redirectUrl = buildAzureBlobUrl(normalizedPath);
+        res.writeHead(302, {
+          Location: redirectUrl,
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end();
+      } catch (error) {
+        console.error('Failed to build Azure Blob redirect URL:', error);
+        sendJson(res, 500, { message: 'Unable to resolve stored file location.' });
+      }
+      return;
+    }
+
+    const filePath = path.resolve(UPLOAD_DIR, normalizedPath);
     const uploadRootWithSeparator = `${UPLOAD_DIR}${path.sep}`;
     if (!(filePath === UPLOAD_DIR || filePath.startsWith(uploadRootWithSeparator))) {
       sendJson(res, 400, { message: 'Invalid file path.' });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -176,6 +176,7 @@ export class AppComponent implements OnInit {
         description: this.uploadDescription.trim(),
         originalName: this.uploadFile.name,
         folder: this.selectedFolder.name,
+        mimeType: this.uploadFile.type,
         data: base64,
       };
 


### PR DESCRIPTION
## Summary
- stream video uploads to Azure Blob Storage using the provided SAS container URL (default updated to the latest token) and return the blob link in metadata
- capture the browser-provided MIME type during uploads so the server can persist accurate content types
- redirect legacy /uploads requests to Azure blobs while preserving existing metadata persistence

## Testing
- `npm test -- --watch=false` *(fails: Chrome browser binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c025adf08322a809a7eb9ecd8228