### PR TITLE
Fix upload failures when Azure storage is unreachable

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,7 @@ interface UploadedVideoRecord {
   createdAt: string;
   thumbnail?: string;
   duration?: string;
+  storage?: 'azure' | 'local';
 }
 
 @Component({


### PR DESCRIPTION
## Summary
- add a storage helper that falls back to writing uploaded files locally when Azure Blob uploads fail
- improve upload validation with clearer errors for invalid or empty base64 payloads
- expose the storage location metadata flag to the Angular client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c8c413848322a987b244713bff92