### PR TITLE
Add cloud video library fetched from remote API

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,6 +10,31 @@
     <button class="cta" type="button" (click)="openUploadModal()">Upload New Video</button>
   </header>
 
+  <section class="cloud-library" aria-label="Cloud video library">
+    <div class="cloud-header">
+      <div>
+        <h2>Cloud Library</h2>
+        <p>Videos available from the Zeus cloud catalog.</p>
+      </div>
+      <span class="cloud-count" *ngIf="cloudVideos.length">{{ cloudVideos.length }} videos</span>
+    </div>
+
+    <ng-container *ngIf="cloudVideos.length; else cloudLibraryState">
+      <div class="cloud-cards">
+        <article class="cloud-card" *ngFor="let video of cloudVideos; trackBy: trackCloudVideo">
+          <div class="thumbnail">
+            <img [src]="video.thumbnail" [alt]="video.displayName + ' thumbnail'" loading="lazy" />
+          </div>
+          <div class="cloud-info">
+            <h3>{{ video.displayName }}</h3>
+            <p>{{ video.contentType }}</p>
+            <span>{{ video.formattedSize }}</span>
+          </div>
+        </article>
+      </div>
+    </ng-container>
+  </section>
+
   <section class="hero">
     <div>
       <h2>{{ selectedFolder.name }}</h2>
@@ -64,6 +89,19 @@
   <div class="empty-state">
     <h3>No videos yet</h3>
     <p>Upload your first video to start building this collection.</p>
+  </div>
+</ng-template>
+
+<ng-template #cloudLibraryState>
+  <div class="cloud-state" *ngIf="cloudLoadError; else cloudStatusNeutral">
+    <p>{{ cloudLoadError }}</p>
+  </div>
+</ng-template>
+
+<ng-template #cloudStatusNeutral>
+  <div class="cloud-state">
+    <p *ngIf="cloudLoading">Loading cloud videos…</p>
+    <p *ngIf="!cloudLoading">No videos found in the cloud library.</p>
   </div>
 </ng-template>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -77,6 +77,98 @@
   transform: none;
 }
 
+.cloud-library {
+  background: white;
+  border-radius: 24px;
+  padding: 28px 32px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: var(--zeus-shadow);
+}
+
+.cloud-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.cloud-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--zeus-dark);
+}
+
+.cloud-header p {
+  margin: 6px 0 0;
+  color: #5f636d;
+}
+
+.cloud-count {
+  background: #ffe1e1;
+  color: var(--zeus-red);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.cloud-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.cloud-card {
+  background: #fef7f7;
+  border-radius: 18px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 28px rgba(229, 57, 53, 0.12);
+}
+
+.cloud-card .thumbnail {
+  aspect-ratio: 16 / 9;
+  background: #d7d7d7;
+}
+
+.cloud-info {
+  padding: 16px 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cloud-info h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--zeus-dark);
+}
+
+.cloud-info p {
+  margin: 0;
+  color: #686d77;
+  font-size: 0.95rem;
+}
+
+.cloud-info span {
+  font-size: 0.9rem;
+  color: #9a9ea7;
+}
+
+.cloud-state {
+  background: #fff5f5;
+  border-radius: 18px;
+  padding: 24px;
+  text-align: center;
+  color: #a25c5c;
+  box-shadow: inset 0 0 0 1px rgba(229, 57, 53, 0.08);
+}
+
 .secondary {
   background: transparent;
   border: 1px solid rgba(0, 0, 0, 0.1);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,22 @@ interface VideoItem {
   src: string;
 }
 
+interface CloudVideoResponse {
+  Name: string;
+  ContentType: string;
+  Size: number;
+}
+
+interface CloudVideoSummary {
+  id: string;
+  name: string;
+  contentType: string;
+  size: number;
+  displayName: string;
+  formattedSize: string;
+  thumbnail: string;
+}
+
 interface Folder {
   name: string;
   description: string;
@@ -42,6 +58,14 @@ interface UploadedVideoRecord {
 export class AppComponent implements OnInit {
   private readonly apiEndpoint = this.resolveApiEndpoint();
   private readonly fallbackThumbnail = 'assets/upload-placeholder.svg';
+  private readonly cloudLibraryEndpoint =
+    'https://zeus-videos-gtcudxfwaaethsa7.southcentralus-01.azurewebsites.net/api/listvideos';
+  private readonly cloudThumbnail =
+    'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80';
+
+  cloudVideos: CloudVideoSummary[] = [];
+  cloudLoadError = '';
+  cloudLoading = true;
 
   readonly folders: Folder[] = [
     {
@@ -109,6 +133,7 @@ export class AppComponent implements OnInit {
   constructor(private readonly http: HttpClient) {}
 
   ngOnInit(): void {
+    this.loadCloudVideos();
     this.loadUploadedVideos();
   }
 
@@ -244,6 +269,70 @@ export class AppComponent implements OnInit {
         console.warn('Unable to load uploaded videos:', error);
       },
     });
+  }
+
+  private loadCloudVideos(): void {
+    this.cloudLoading = true;
+    this.http.get<CloudVideoResponse[]>(this.cloudLibraryEndpoint).subscribe({
+      next: (videos) => {
+        this.cloudLoadError = '';
+        this.cloudVideos = videos.map((video, index) => this.mapCloudVideo(video, index));
+        this.cloudLoading = false;
+      },
+      error: (error) => {
+        console.warn('Unable to load cloud videos:', error);
+        this.cloudLoadError = 'Unable to load the cloud video library right now. Please try again later.';
+        this.cloudLoading = false;
+      },
+    });
+  }
+
+  private mapCloudVideo(video: CloudVideoResponse, index: number): CloudVideoSummary {
+    const id = `${video.Name}-${index}`;
+    return {
+      id,
+      name: video.Name,
+      contentType: video.ContentType,
+      size: video.Size,
+      displayName: this.getCloudVideoDisplayName(video.Name),
+      formattedSize: this.formatFileSize(video.Size),
+      thumbnail: this.cloudThumbnail,
+    };
+  }
+
+  private getCloudVideoDisplayName(name: string): string {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return 'Untitled Video';
+    }
+
+    const lastDot = trimmed.lastIndexOf('.');
+    if (lastDot <= 0) {
+      return trimmed;
+    }
+
+    return trimmed.slice(0, lastDot);
+  }
+
+  private formatFileSize(size: number): string {
+    if (!Number.isFinite(size) || size <= 0) {
+      return 'Unknown size';
+    }
+
+    const units = ['bytes', 'KB', 'MB', 'GB', 'TB'];
+    let index = 0;
+    let value = size;
+
+    while (value >= 1024 && index < units.length - 1) {
+      value /= 1024;
+      index += 1;
+    }
+
+    return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+  }
+
+  trackCloudVideo(_: number, video: CloudVideoSummary): string {
+    return video.id;
   }
 
   private addUploadedVideo(record: UploadedVideoRecord): void {


### PR DESCRIPTION
## Summary
- fetch the remote cloud video library on page load and transform file metadata into display-friendly values
- surface a new Cloud Library section with reusable thumbnail styling and informative fallback states

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dca55a9324832286f626a6b1b0c2f8