### PR TITLE
Add passcode-protected playback flow

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,7 +20,15 @@
 
     <ng-container *ngIf="cloudVideos.length; else cloudLibraryState">
       <div class="cloud-cards">
-        <article class="cloud-card" *ngFor="let video of cloudVideos; trackBy: trackCloudVideo">
+        <button
+          type="button"
+          class="cloud-card"
+          *ngFor="let video of cloudVideos; trackBy: trackCloudVideo"
+          (click)="requestPlayback(video)"
+          [disabled]="requestingVideoId === video.id"
+          [attr.aria-busy]="requestingVideoId === video.id ? 'true' : null"
+          [attr.aria-label]="'Request playback for ' + video.displayName"
+        >
           <div class="thumbnail">
             <img [src]="video.thumbnail" [alt]="video.displayName + ' thumbnail'" loading="lazy" />
           </div>
@@ -29,9 +37,42 @@
             <p>{{ video.contentType }}</p>
             <span>{{ video.formattedSize }}</span>
           </div>
-        </article>
+        </button>
       </div>
     </ng-container>
+    <section class="playback-status" *ngIf="playbackState !== 'idle'">
+      <ng-container [ngSwitch]="playbackState">
+        <p *ngSwitchCase="'loading'">Requesting playback for {{ playbackVideoTitle }}…</p>
+
+        <div *ngSwitchCase="'success'" class="playback-success">
+          <h3>Playback ready for {{ playbackVideoTitle }}</h3>
+          <p>
+            The secure link expires at
+            <span>{{ playbackExpiresAt || 'the provided expiration time' }}</span>.
+          </p>
+          <a
+            class="playback-link"
+            [href]="playbackUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open video in a new tab
+          </a>
+          <video
+            *ngIf="playbackUrl"
+            class="playback-video"
+            controls
+            [src]="playbackUrl"
+          ></video>
+        </div>
+
+        <div *ngSwitchCase="'error'" class="playback-error">
+          <h3>Unable to start playback for {{ playbackVideoTitle || 'the selected video' }}</h3>
+          <p>The server responded with:</p>
+          <pre>{{ playbackErrorMessage }}</pre>
+        </div>
+      </ng-container>
+    </section>
   </section>
 </div>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -103,6 +103,28 @@
   display: flex;
   flex-direction: column;
   box-shadow: 0 12px 28px rgba(229, 57, 53, 0.12);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  font: inherit;
+  color: inherit;
+}
+
+.cloud-card:focus-visible {
+  outline: 3px solid rgba(229, 57, 53, 0.6);
+  outline-offset: 3px;
+}
+
+.cloud-card:hover:not(:disabled) {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 32px rgba(229, 57, 53, 0.18);
+}
+
+.cloud-card:disabled {
+  cursor: progress;
+  opacity: 0.7;
 }
 
 .cloud-card .thumbnail {
@@ -148,6 +170,62 @@
   text-align: center;
   color: #a25c5c;
   box-shadow: inset 0 0 0 1px rgba(229, 57, 53, 0.08);
+}
+
+.playback-status {
+  margin-top: 24px;
+  background: #fff5f5;
+  border-radius: 18px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #5f1f1f;
+  box-shadow: inset 0 0 0 1px rgba(229, 57, 53, 0.12);
+}
+
+.playback-success h3,
+.playback-error h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.playback-success p,
+.playback-error p {
+  margin: 0;
+}
+
+.playback-link {
+  align-self: flex-start;
+  background: var(--zeus-red);
+  color: white;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.playback-link:hover,
+.playback-link:focus-visible {
+  background: #c62828;
+  transform: translateY(-1px);
+}
+
+.playback-video {
+  width: 100%;
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(229, 57, 53, 0.25);
+}
+
+.playback-error pre {
+  margin: 0;
+  background: rgba(229, 57, 53, 0.12);
+  padding: 12px;
+  border-radius: 12px;
+  font-family: 'Fira Code', 'Courier New', Courier, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- prompt for a passcode when a cloud thumbnail is selected and request a playback URL from the Zeus API
- surface success and failure responses, including the secure SAS link and any server error details, directly in the UI
- refresh the cloud card styling to reflect button behavior and add feedback styling for the playback status panel

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dcaadf1a2483229e692a7078c23a5b