### PR TITLE
Add fullscreen playback modal for videos

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -48,20 +48,24 @@
           <p class="playback-countdown" *ngIf="playbackExpiryCountdown">
             Video valid for: <span>{{ playbackExpiryCountdown }}</span>
           </p>
-          <a
-            class="playback-link"
-            [href]="playbackUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Open video in a new tab
-          </a>
-          <video
-            *ngIf="playbackUrl"
-            class="playback-video"
-            controls
-            [src]="playbackUrl"
-          ></video>
+          <div class="playback-actions">
+            <button
+              type="button"
+              class="playback-open-button"
+              (click)="openPlaybackModal()"
+              [disabled]="!playbackUrl"
+            >
+              Watch in fullscreen player
+            </button>
+            <a
+              class="playback-link"
+              [href]="playbackUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open video in a new tab
+            </a>
+          </div>
         </div>
 
         <div *ngSwitchCase="'error'" class="playback-error">
@@ -85,3 +89,28 @@
     <p *ngIf="!cloudLoading">No videos found in the cloud library.</p>
   </div>
 </ng-template>
+
+<div
+  *ngIf="isPlaybackModalOpen && playbackUrl"
+  class="playback-overlay"
+  role="dialog"
+  aria-modal="true"
+  [attr.aria-label]="'Video player for ' + playbackVideoTitle"
+>
+  <div class="playback-overlay__content">
+    <button
+      type="button"
+      class="playback-overlay__close"
+      (click)="closePlaybackModal(overlayVideo)"
+    >
+      Close video
+    </button>
+    <video
+      #overlayVideo
+      class="playback-overlay__video"
+      controls
+      autoplay
+      [src]="playbackUrl"
+    ></video>
+  </div>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -227,6 +227,37 @@
   transform: translateY(-1px);
 }
 
+.playback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.playback-open-button {
+  background: white;
+  color: var(--zeus-red);
+  border: 2px solid var(--zeus-red);
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.playback-open-button:hover:not(:disabled),
+.playback-open-button:focus-visible:not(:disabled) {
+  background: var(--zeus-red);
+  color: white;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.playback-open-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .playback-error-message {
   margin-top: 8px;
   background: rgba(229, 57, 53, 0.12);
@@ -234,12 +265,6 @@
   border-radius: 12px;
   font-weight: 500;
   color: #7f1d1d;
-}
-
-.playback-video {
-  width: 100%;
-  border-radius: 16px;
-  box-shadow: 0 10px 24px rgba(229, 57, 53, 0.25);
 }
 
 .playback-error pre {
@@ -271,5 +296,71 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+.playback-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: rgba(15, 23, 42, 0.78);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+}
+
+.playback-overlay__content {
+  width: min(1200px, 100%);
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.playback-overlay__close {
+  align-self: flex-end;
+  background: rgba(15, 15, 15, 0.7);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.playback-overlay__close:hover,
+.playback-overlay__close:focus-visible {
+  background: rgba(15, 15, 15, 0.9);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.playback-overlay__video {
+  width: 100%;
+  max-height: calc(100vh - 160px);
+  border-radius: 20px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+  background: black;
+}
+
+@media (max-width: 640px) {
+  .playback-overlay {
+    padding: 16px;
+  }
+
+  .playback-overlay__content {
+    gap: 12px;
+  }
+
+  .playback-overlay__close {
+    align-self: stretch;
+    text-align: center;
+  }
+
+  .playback-overlay__video {
+    max-height: calc(100vh - 120px);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,6 +48,7 @@ export class AppComponent implements OnInit, OnDestroy {
   playbackUrl = '';
   playbackExpiryCountdown = '';
   playbackErrorMessage = '';
+  isPlaybackModalOpen = false;
   requestingVideoId: string | null = null;
   private playbackTimerId: number | null = null;
 
@@ -59,6 +60,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.clearPlaybackTimer();
+    this.setBodyScrollLocked(false);
   }
 
   private loadCloudVideos(): void {
@@ -139,6 +141,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this.playbackVideoTitle = video.displayName;
       this.playbackErrorMessage = 'A passcode is required to request playback.';
       this.playbackUrl = '';
+      this.closePlaybackModal();
       this.requestingVideoId = null;
       return;
     }
@@ -148,6 +151,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.playbackUrl = '';
     this.playbackExpiryCountdown = '';
     this.playbackErrorMessage = '';
+    this.closePlaybackModal();
     this.requestingVideoId = video.id;
     this.clearPlaybackTimer();
 
@@ -162,6 +166,7 @@ export class AppComponent implements OnInit, OnDestroy {
           this.playbackUrl = response.playbackUrl;
           this.playbackErrorMessage = '';
           this.requestingVideoId = null;
+          this.openPlaybackModal();
           this.startPlaybackCountdown(response.expiresAt);
         },
         error: (error) => {
@@ -169,6 +174,7 @@ export class AppComponent implements OnInit, OnDestroy {
           this.playbackErrorMessage = this.formatPlaybackError(error);
           this.playbackUrl = '';
           this.playbackExpiryCountdown = '';
+          this.closePlaybackModal();
           this.requestingVideoId = null;
           this.clearPlaybackTimer();
         },
@@ -270,6 +276,32 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private pad(value: number): string {
     return value.toString().padStart(2, '0');
+  }
+
+  openPlaybackModal(): void {
+    if (!this.playbackUrl) {
+      return;
+    }
+
+    this.isPlaybackModalOpen = true;
+    this.setBodyScrollLocked(true);
+  }
+
+  closePlaybackModal(videoElement?: HTMLVideoElement | null): void {
+    if (videoElement) {
+      videoElement.pause();
+    }
+
+    this.isPlaybackModalOpen = false;
+    this.setBodyScrollLocked(false);
+  }
+
+  private setBodyScrollLocked(locked: boolean): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.body.style.overflow = locked ? 'hidden' : '';
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the inline playback element with a fullscreen modal video player and supporting controls
- add component logic to open/close the modal, pause playback when closing, and lock background scrolling during playback
- refresh success state actions with a fullscreen watch button alongside the existing external link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb6af18448322820fe3d845280625